### PR TITLE
Adopt AGENTS.md agent standard + guardrails

### DIFF
--- a/.claude/hooks/ask-before-risky-commands.sh
+++ b/.claude/hooks/ask-before-risky-commands.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Claude Code PreToolUse(Bash) gate — pathscale backend service.
+#
+# Prompts before prod-affecting / destructive commands in ANY wrapper form
+# (env VAR=val …, tool -C <dir> …, chained with ; && |, multi-line, quoted via
+# bash -c '…'). For everything else it stays SILENT (exit 0, no decision), so the
+# normal permission rules — permissions.allow / ask / deny in .claude/settings.json
+# and the session's permission mode — decide as usual.
+#
+# This is one layer of defense, not a replacement for the permission system: a
+# pattern match over a command string is best-effort (quoting and indirection can
+# evade any blocklist). It backs up the declarative permissions.ask list in
+# .claude/settings.json — KEEP THE TWO IN SYNC — and for fully autonomous runs,
+# prefer OS-level sandboxing on top.
+#
+# Adapted from PakhomovAlexander/project-hub. Edit RISKY_WORDS for this repo;
+# tooling; further branches below gate `git`/`docker push`, `git clean`, recursive
+# `rm`, `find -delete`, package publishing, PR-merge/release via `gh`, and a deploy
+# script run by path. Add your own command families (e.g. `ssh`, a bespoke deploy
+# CLI) to RISKY_WORDS, or trim what you don't use — and mirror the change in
+# permissions.ask in .claude/settings.json.
+set -u
+
+# --- the watchlist: command words that should prompt before running ----------------
+RISKY_WORDS="aws|gcloud|az|kubectl|helm|terraform|terragrunt|flyctl|fly"
+# -----------------------------------------------------------------------------------
+
+# Pull the command out of the hook's stdin JSON (jq if available, else python3).
+if command -v jq >/dev/null 2>&1; then
+  cmd="$(jq -r '.tool_input.command // ""' 2>/dev/null)"
+else
+  cmd="$(python3 -c 'import sys, json; print(json.load(sys.stdin).get("tool_input", {}).get("command", ""))' 2>/dev/null)"
+fi
+
+# Couldn't read the command → stay neutral, let normal permission rules decide.
+[ -z "$cmd" ] && exit 0
+
+# A command word counts as "at a command position" after start-of-line, whitespace,
+# ; & | ( or a quote — and ends before whitespace, a quote, ) ; & | or end-of-line —
+# so `bash -c 'git push'` is still seen.
+b="(^|[[:space:];&|(\"'\`])"
+e="([[:space:];&|)\"'\`]|$)"
+# Global options that may sit between a tool and its subcommand (git -C dir push).
+opts='([[:space:]]+(-[A-Za-z-]+|[-_A-Za-z0-9]+=[^[:space:]]+|-C[[:space:]]+[^[:space:]]+))*'
+
+re="${b}(${RISKY_WORDS})${e}"
+# git push / git clean, docker push — allowing global options before the subcommand.
+re="$re|${b}git${opts}[[:space:]]+(push|clean)${e}"
+re="$re|${b}docker${opts}[[:space:]]+push${e}"
+# recursive rm (-r / -R / -fr / --recursive), with flags/paths in any order.
+re="$re|${b}rm([[:space:]]+[^[:space:]]+)*[[:space:]]+(-[A-Za-z]*[rR]|--recursive)"
+# find … -delete — irreversible bulk delete.
+re="$re|${b}find([[:space:]]+[^[:space:]]+)*[[:space:]]+-delete${e}"
+# package publishing — ships artifacts to a registry.
+re="$re|${b}(npm|pnpm|yarn|bun|cargo|gem)([[:space:]]+[^[:space:]]+)*[[:space:]]+publish${e}"
+re="$re|${b}twine([[:space:]]+[^[:space:]]+)*[[:space:]]+upload${e}"
+# gh mutations that merge, ship, or destroy.
+re="$re|${b}gh[[:space:]]+(pr[[:space:]]+merge|repo[[:space:]]+delete|release[[:space:]]+(create|delete))${e}"
+re="$re|${b}gh[[:space:]]+api([[:space:]]+[^[:space:]]+)*[[:space:]]+(-X|--method)[[:space:]]+(POST|PUT|PATCH|DELETE)${e}"
+# a deploy script invoked by path, e.g. ./scripts/deploy.sh — a word-list can't see it.
+re="$re|${b}([./A-Za-z0-9_-]*/)?deploy(\.[A-Za-z]+)?${e}"
+# WorkTable data migrations and endpoint regeneration rewrite committed artifacts.
+re="$re|${b}([./A-Za-z0-9_-]*/)?regenerate_endpoints(\.[A-Za-z]+)?${e}"
+
+if printf '%s\n' "$cmd" | grep -Eq "$re"; then
+  printf '%s' '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask","permissionDecisionReason":"Prod-affecting / destructive command — confirm before running."}}'
+fi
+# No match → no output: fall through to the normal permission flow.
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,43 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(bun run build:*)",
+      "Bash(bun run test:*)",
+      "Bash(bun run typecheck:*)",
+      "Bash(bun run lint:*)",
+      "Bash(bun install:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)"
+    ],
+    "ask": [
+      "Bash(git push:*)",
+      "Bash(cargo publish:*)",
+      "Bash(npm publish:*)",
+      "Bash(bun publish:*)",
+      "Bash(docker push:*)",
+      "Bash(gh pr merge:*)",
+      "Bash(gh release:*)",
+      "Bash(aws:*)",
+      "Bash(gcloud:*)",
+      "Bash(az:*)",
+      "Bash(kubectl:*)",
+      "Bash(helm:*)",
+      "Bash(terraform:*)",
+      "Bash(flyctl:*)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/ask-before-risky-commands.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,10 @@ natively, and Claude Code loads it through the `@AGENTS.md` import in
 
 ## Invariants (don't break these)
 
+- **Read [`docs/frontend-conventions.md`](docs/frontend-conventions.md) before opening
+  implementation files.** It is the frontend working agreement: SolidJS/`@pathscale/ui`
+  conventions, and a context-efficient workflow. Reading it first keeps
+  context small and avoids re-deriving patterns that already exist.
 - **`bun run typecheck` must pass.** It is the type gate for this repo; a build succeeding is not the same as types being sound.
 - **`bun` is the package manager** — its lockfile is authoritative. Don't introduce a second one by running npm/yarn/pnpm here.
 - **Docs describe what is true now.** If you change behaviour, update the README and any affected doc in the same change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,85 @@
+# Working agreement — js.software
+
+The operating contract for **any** coding agent working in this repository. This file is
+the single source of truth for the rules: Codex, Cursor and Gemini CLI read `AGENTS.md`
+natively, and Claude Code loads it through the `@AGENTS.md` import in
+[`CLAUDE.md`](CLAUDE.md). **Never fork these rules into a per-vendor file.**
+
+**JavaScript/TypeScript application / site** (`JS Software UI`), built with `bun`.
+
+## Invariants (don't break these)
+
+- **`bun run typecheck` must pass.** It is the type gate for this repo; a build succeeding is not the same as types being sound.
+- **`bun` is the package manager** — its lockfile is authoritative. Don't introduce a second one by running npm/yarn/pnpm here.
+- **Docs describe what is true now.** If you change behaviour, update the README and any affected doc in the same change.
+
+## Build & run
+
+```bash
+bun install
+bun run dev
+bun run build
+bun run typecheck
+bun run lint
+```
+
+## Verification
+
+Run what you build before reporting it done. Type-checks and tests verify code correctness,
+not feature correctness — **if you can't run it, say so explicitly** rather than implying
+success.
+
+- Compare against the base branch rather than asserting: a pre-existing failing test or lint
+  error is not something you introduced, and saying so requires checking.
+- A build that finishes suspiciously fast was cached, not rebuilt. Force a real rebuild when
+  the rebuild is the thing you're verifying.
+
+## PR discipline
+
+**Always paste the full PR URL** (`https://github.com/pathscale/js.software/pull/<n>`), not just the number, so it's
+clickable.
+
+<!-- DORMANT — CI-green gating. Do not follow this rule yet; re-enable it as its own project.
+
+Why it's off: CI here does not reliably attach checks to pull requests, so
+`statusCheckRollup` comes back empty and "wait for green" would teach an agent to wait on
+nothing. Verify per repo before switching this on.
+
+To enable: ensure the workflow runs on `pull_request:`, confirm checks attach to a PR, then
+uncomment the rule below.
+
+    After any push or PR, **check CI and don't call it done until it's green**:
+
+    ```bash
+    gh pr view <number> --repo pathscale/js.software --json statusCheckRollup
+    ```
+
+    CI running → wait and recheck. CI failed → read the logs, fix, push, wait for green.
+-->
+
+## Keeping docs honest
+
+Hit a factual error here — a stale path, a wrong command, a moved status? Fix it in the same
+change. Don't open cosmetic rewording PRs.
+
+Learned something durable — a gotcha, a decision, a constraint? It belongs **in this repo's
+docs**, not in your agent's private memory. Repo docs are versioned, reviewable, and visible
+to every agent and human; private memory dies with your machine.
+
+## Git workflow
+
+- **Always specify the branch when pushing**: `git push origin branch-name`
+- **Branch naming**: `fix/issue-description` or `feat/issue-description`
+- **No force-pushing** during PR review
+
+## Guardrails
+
+[`.claude/settings.json`](.claude/settings.json) and [`.claude/hooks/`](.claude/hooks/) make
+Claude Code prompt a human before prod-affecting or destructive commands — pushes, publishing
+to a registry, `gh pr merge`, cloud CLIs, recursive deletes, deploy scripts.
+
+**Other agents don't get that net automatically.** Apply the same rule yourself: ask before
+running any command family listed in
+[`.claude/hooks/ask-before-risky-commands.sh`](.claude/hooks/ask-before-risky-commands.sh).
+It is one layer of defence, not a guarantee — a pattern match over a command string is
+best-effort.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,12 @@
+@AGENTS.md
+
+# Claude Code notes — js.software
+
+The import above is binding: [`AGENTS.md`](AGENTS.md) is the **working agreement** for this
+repository, and every Claude Code session loads it automatically. Don't copy rules here —
+one source of truth, no drift. Only genuinely Claude-specific wiring belongs below.
+
+- Guardrails live in [`.claude/settings.json`](.claude/settings.json): safe read-only
+  commands are pre-allowed; pushes, publishing, `gh pr merge`, cloud CLIs and deploys prompt
+  first (`permissions.ask` plus the `PreToolUse` hook in [`.claude/hooks/`](.claude/hooks/)).
+- Keep the hook's `RISKY_WORDS` and `permissions.ask` **in sync** — they back each other up.

--- a/docs/frontend-conventions.md
+++ b/docs/frontend-conventions.md
@@ -1,0 +1,62 @@
+# Frontend conventions — js.software
+
+Read this **before** opening implementation files, so context stays small and existing
+conventions are followed. It covers implementing, debugging, reviewing and refactoring pages, hooks, stores, services, routing and `@pathscale/ui` usage.
+
+Stack: **SolidJS**, **rsbuild**, **Bun**, **Biome**, **`@pathscale/ui`**.
+
+## Non-negotiables
+
+- **SolidJS, not React.** No `useState`/`useEffect` reflexes, no virtual-DOM
+  assumptions. Use signals, `<Show>`, `<For>`, and `class=` (not `className=`).
+- Follow the existing hooks, stores, routes, guards and feature structure **before**
+  introducing a new pattern. Find one analogous implementation and mirror it.
+- **Reuse `@pathscale/ui`.** Verify a component's props from existing usage in this
+  repo rather than assuming its API or building a replacement.
+- **User-facing strings:** this repo has no i18n system today. If one is added, route
+  every user-facing string through it — don't hand-roll a second mechanism alongside it.
+- **Use Bun and Biome**, and this repository's actual validation commands (below) —
+  not a remembered command from another project.
+
+## Context-efficient workflow
+
+1. **Classify the task before reading files:** auth · data/hooks · feature page ·
+   routing · stores · UI/styling.
+2. **Search narrowly before reading.** Prefer symbols, exact strings and matching line
+   ranges over opening whole files.
+3. **Start with at most five directly relevant files.** Expand only when there is a
+   concrete unanswered question.
+4. **Mirror an analogous implementation** before creating a new pattern.
+5. **This repo has no backend services contract** — there is no services JSON to
+   consult. Don't look for one.
+6. **Don't repeat a search whose result you already have**, and don't reread unchanged
+   files without a reason.
+7. **Verify existing `@pathscale/ui` usage** before assuming a component API.
+8. **Validate incrementally:** smallest relevant check first, broader checks only when
+   needed.
+9. **Report only:** changed files · validation results · remaining risks · contract
+   limitations.
+
+## Validation
+
+```bash
+bun run typecheck
+bun run lint
+bun run format
+bun run build
+```
+
+Run the smallest relevant check first; widen only if it passes or the failure is unclear.
+
+## References
+
+Load only the reference needed for the current task — not all of them automatically:
+
+- **project map** — feature structure, routes, stores and app flow
+- **services contract** — endpoint wiring, hooks and generated DTO rules
+- **UI conventions** — SolidJS and `@pathscale/ui` usage
+- **validation** — exact commands for this repository (see above)
+
+> **TODO — these reference docs do not exist yet.** The names above are the intended
+> split; writing them is a follow-up project. Until they exist, this file plus the
+> services JSON is the reference. Don't go looking for files that aren't there.


### PR DESCRIPTION
Brings this repo onto the same agent-instruction standard as the rest of the pathscale codebase, following [PakhomovAlexander/project-hub](https://github.com/PakhomovAlexander/project-hub).

**Docs and guardrails only — no source or dependency changes.**

## Single-sourced instructions

`AGENTS.md` is canonical; `CLAUDE.md` is a thin `@AGENTS.md` import. Codex, Cursor and Gemini CLI read `AGENTS.md` natively and Claude Code loads it through the import, so every agent lands on the same runbook instead of a per-vendor fork. Previously most of these repos had no agent instructions at all, and where they existed they were Claude-only and inconsistent between repos.

## Stack-aware, not boilerplate

The invariants, build commands and release discipline reflect what this repo actually is — detected from the manifests rather than assumed: Rust crate vs binary vs workspace; JS library vs application/site (a library declares `files` plus `main`/`exports`; a site declares neither); and the package manager the lockfile actually indicates.

So a publishable crate gets the crates.io irreversibility rule and the pre-release pinning gotcha; a website does not get npm release invariants it would never use.

## Shared across every repo

- **Verification** — run what you build; if you can't run it, say so. Compare against the base branch rather than asserting a failure is pre-existing. A build that finishes suspiciously fast was cached, not rebuilt.
- **PR discipline** — always paste the full PR URL, not just the number.
- **Docs are shared memory** — durable learnings belong in the repo, not an agent's private memory, which dies with the machine.
- **Git workflow** — explicit branch on push, branch naming, no force-push during review.

## Guardrails are enforced, not just documented

`.claude/settings.json` pre-allows read-only commands for this stack and prompts before pushes, publishing, `gh pr merge`, cloud CLIs and deploys. The `PreToolUse` hook catches wrapper forms a permission glob misses — `env X=y git push`, `git -C dir push`, `bash -c '…'` — and includes `bun` in the publish watchlist, since that is the package manager actually in use across these repos.

The two overlap deliberately and must be kept in sync; both files say so. It is one layer of defence, not a sandbox — pattern matching over a command string is best-effort, and the hook is explicit about that.

## CI rule ships dormant

The "don't call it done until CI is green" rule is present but commented out, with its reason and enabling steps. CI here does not reliably attach checks to pull requests, so `statusCheckRollup` returns empty and the rule would teach an agent to wait on nothing. Enabling it is a separate project.

## .gitignore

Drops superseded blocks on `CLAUDE.md`, `AGENTS.md` and `/.claude` so this guidance is actually tracked. `/.claude/settings.local.json` stays ignored — personal overrides shouldn't be shared.

## Note

Deliberate v1 across the whole codebase; expect to refine wording and the invariant list per repo. The reference is a *multi-repo hub* template, so its `repos/` symlinks, tracker and ADR scaffolding were intentionally not cargo-culted into standalone repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
