### PR TITLE
docs: forbid merge commits, prefer rebase when landing PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,17 @@ to every agent and human; private memory dies with your machine.
   `--force-with-lease` so you don't clobber someone else's push.
 - **Never force-push the default branch** (`main`/`master`). That is the history
   everyone else builds on, and it is protected server-side for a reason.
+- **Never create merge commits.** Not locally, not to refresh a branch. If your branch
+  has fallen behind, **rebase** it onto the moved base (`git rebase origin/master`, then
+  `--force-with-lease`). `git merge master` into a feature branch is not an acceptable
+  shortcut: it adds a commit whose only content is the fact that you were behind, and it
+  turns a readable line of work into a diamond. Merge commits are disabled server-side on
+  these repositories — that is a backstop, not a licence to rely on it.
+- **Land pull requests with rebase, not squash.** Individual commits carry information:
+  what was tried, in what order, and why. Squashing throws that away and leaves one
+  commit whose message can only summarise. Write commits worth keeping, then land them
+  intact. Reach for squash only when a branch is genuinely one logical change scattered
+  across fixup commits.
 
 ## Guardrails
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,17 +79,21 @@ to every agent and human; private memory dies with your machine.
   `--force-with-lease` so you don't clobber someone else's push.
 - **Never force-push the default branch** (`main`/`master`). That is the history
   everyone else builds on, and it is protected server-side for a reason.
-- **Never create merge commits.** Not locally, not to refresh a branch. If your branch
+- **Never create merge commits — this is a hard ban.** Not locally, not to refresh a
+  branch, not to land a pull request. If your branch
   has fallen behind, **rebase** it onto the moved base (`git rebase origin/master`, then
   `--force-with-lease`). `git merge master` into a feature branch is not an acceptable
   shortcut: it adds a commit whose only content is the fact that you were behind, and it
   turns a readable line of work into a diamond. Merge commits are disabled server-side on
   these repositories — that is a backstop, not a licence to rely on it.
-- **Land pull requests with rebase, not squash.** Individual commits carry information:
-  what was tried, in what order, and why. Squashing throws that away and leaves one
-  commit whose message can only summarise. Write commits worth keeping, then land them
-  intact. Reach for squash only when a branch is genuinely one logical change scattered
-  across fixup commits.
+- **Rebase is the default everywhere** — refreshing a branch, and landing a pull request.
+  Individual commits carry information: what was tried, in what order, and why. A rebase
+  merge keeps that granularity on the base branch, so write commits worth keeping and land
+  them intact.
+- **Squash is acceptable** where it genuinely makes things easier or is the more
+  appropriate shape for the branch — one logical change scattered across fixup commits, or
+  a long branch whose intermediate states aren't worth preserving. It is a judgement call,
+  not a violation. Merging is the only thing that is never allowed.
 
 ## Guardrails
 


### PR DESCRIPTION
Two working-agreement rules that were practice but undocumented — so an agent reading `AGENTS.md` had no way to follow them. I broke both today, which is how they surfaced.

**No merge commits.** Refreshing a feature branch with `git merge master` adds a commit whose only content is that you were behind, and turns a readable line of work into a diamond. Rebase onto the moved base instead. The existing force-push bullet already blessed rebasing — this states plainly that merging is not the alternative to it.

**Land PRs with rebase, not squash.** Individual commits carry what was tried and in what order; squashing collapses that into a single message that can only summarise. Squash stays available for the case it suits: one logical change scattered across fixup commits.

Identical wording in all ten frontend repos, appended to the existing **Git workflow** section.

## Worth knowing

`allow_merge_commit` is already `false` on every one of these repos, so rule one has a server-side backstop. **`allow_squash_merge` is still `true`**, so rule two is convention only right now. Say the word and I'll turn squash off in the repo settings so the setting matches the agreement — I have not touched repo settings on my own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)