### PR TITLE
fix: update UI syntax token isolation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "@commitlint/config-conventional": "^19.0.3",
         "@commitlint/cz-commitlint": "^19.8.1",
         "@iconify/tailwind4": "^1.0.6",
-        "@pathscale/ui": "^2.1.0",
+        "@pathscale/ui": "^2.1.1",
         "@rsbuild/core": "^1.3.20",
         "@rsbuild/plugin-babel": "^1.0.5",
         "@rsbuild/plugin-solid": "^1.0.5",
@@ -238,7 +238,7 @@
 
     "@pathscale/rsbuild-plugin-iconify": ["@pathscale/rsbuild-plugin-iconify@1.0.4", "", { "dependencies": { "@iconify/json": "^2.2.481", "@iconify/utils": "^2.3.0", "@rspack/core": "^1.7.11", "cssnano": "^7.1.9", "postcss": "^8.5.15", "postcss-cli": "^11.0.1", "svgo": "^3.3.3" }, "peerDependencies": { "@rsbuild/core": "^1.3.22", "@rslib/core": "^0.9.1" } }, "sha512-KrCuzAa9AzbXojh7ne+yfldfipWZ39d/BFfwDhLNlDvQxpena5I/0h4eoa4x4RlaCux6h+Ay81KmHGrdR0tpyw=="],
 
-    "@pathscale/ui": ["@pathscale/ui@2.1.0", "", { "dependencies": { "@iconify/tailwind4": "^1.2.3", "@pathscale/rsbuild-plugin-iconify": "^1.0.4", "@tanstack/solid-virtual": "^3.13.27", "tailwind-merge": "^3.6.0" }, "peerDependencies": { "@solid-primitives/event-listener": "^2.3.0", "@solid-primitives/intersection-observer": "^2.1.3", "@solid-primitives/keyboard": "^1.2.5", "@solid-primitives/media": "^2.2.5", "@solid-primitives/props": "^3.1.8", "@solid-primitives/resize-observer": "^2.0.22", "@solid-primitives/scheduled": "^1.4.1", "@solid-primitives/scroll": "^2.0.20", "@solid-primitives/storage": "^2.1.1", "@solid-primitives/utils": "^6.2.1", "@standard-schema/spec": "^1.0.0", "@tanstack/solid-form": "^1.29.0", "@tanstack/solid-table": "^8.0.0", "popmotion": "^11.0.5", "solid-js": "^1.9", "solid-layouts": "^0.1.2" }, "optionalPeers": ["@standard-schema/spec", "popmotion"] }, "sha512-UKbHYL4fPX+8e/JoVb1Tw3q6hRU5hYoIDX0Uvy94oQ8QBQPRyZ2xof11x1gxYQLr6ubiFvSxd75AmfiH+qrHsw=="],
+    "@pathscale/ui": ["@pathscale/ui@2.1.1", "", { "dependencies": { "@iconify/tailwind4": "^1.2.3", "@pathscale/rsbuild-plugin-iconify": "^1.0.4", "@tanstack/solid-virtual": "^3.13.27", "tailwind-merge": "^3.6.0" }, "peerDependencies": { "@solid-primitives/event-listener": "^2.3.0", "@solid-primitives/intersection-observer": "^2.1.3", "@solid-primitives/keyboard": "^1.2.5", "@solid-primitives/media": "^2.2.5", "@solid-primitives/props": "^3.1.8", "@solid-primitives/resize-observer": "^2.0.22", "@solid-primitives/scheduled": "^1.4.1", "@solid-primitives/scroll": "^2.0.20", "@solid-primitives/storage": "^2.1.1", "@solid-primitives/utils": "^6.2.1", "@standard-schema/spec": "^1.0.0", "@tanstack/solid-form": "^1.29.0", "@tanstack/solid-table": "^8.0.0", "popmotion": "^11.0.5", "solid-js": "^1.9", "solid-layouts": "^0.1.2" }, "optionalPeers": ["@standard-schema/spec", "popmotion"] }, "sha512-xU9hkCd8hHcpF1xwcmgNDZbE6U77HwGTeeqZfYnYK0MV8yW1EdHCRT+sa8CFK9RYjiM1FOrM7+1t39bPCDkQbQ=="],
 
     "@rsbuild/core": ["@rsbuild/core@1.3.20", "", { "dependencies": { "@rspack/core": "1.3.10", "@rspack/lite-tapable": "~1.0.1", "@swc/helpers": "^0.5.17", "core-js": "~3.42.0", "jiti": "^2.4.2" }, "bin": { "rsbuild": "bin/rsbuild.js" } }, "sha512-5VxOddgGHaq5x4ONdKOZvLYLj8dhVfCAz+cERNLXrKLzBISouY1A9TJcbZBK4xoH/0DJrDtDzapNA+dI9Jr07Q=="],
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@commitlint/config-conventional": "^19.0.3",
     "@commitlint/cz-commitlint": "^19.8.1",
     "@iconify/tailwind4": "^1.0.6",
-    "@pathscale/ui": "^2.1.0",
+    "@pathscale/ui": "^2.1.1",
     "@rsbuild/core": "^1.3.20",
     "@rsbuild/plugin-babel": "^1.0.5",
     "@rsbuild/plugin-solid": "^1.0.5",


### PR DESCRIPTION
## Summary

- update `@pathscale/ui` to 2.1.1
- consume the Tag selector isolation fix for Prism syntax highlighting

## Verification

- typecheck passed
- production build passed
- visually inspected `/dropdown`
- 156 Prism tag tokens render inline with zero padding and transparent backgrounds